### PR TITLE
add brew & scoop setup

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,27 @@ nfpms:
       - deb
       - rpm
       - apk
+brews:
+  - tap:
+      owner: svixhq
+      name: homebrew-svix
+    commit_author:
+      name: svix-ci
+      email: support@svix.com
+    homepage: https://www.svix.com
+    description: Svix CLI utility
+    install: |
+      bin.install "svix"
+    caveats: "Thanks for installing the Svix CLI! If this is your first time using the CLI, checkout our docs at https://docs.svix.com."
+scoop:
+  bucket:
+    owner: svixhq
+    name: scoop-svix
+  commit_author:
+    name: svix-ci
+    email: support@svix.com
+  homepage: https://www.svix.com
+  description: Svix CLI utility
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Okay @tasn I lied, both the brew and scoop need to live in separate repos, I propose two repos: `homebrew-svix` and `scoop-svix`

The Homebrew flow can then look like this 
```sh
brew tap svixhq/svix
brew install svix
# or
brew install svixhq/svix/svix
```
and the scoop flow will look like this:
```sh
scoop bucket add svix https://github.com/svixhq/scoop-svix.git
scoop install svix
```

Additionally before I can merge this, I need to get setup with access to `secrets` for this repo as well as write access to the newly created repos.

Closes #1.